### PR TITLE
Added files for QLF_K4N8 24x24 device

### DIFF
--- a/qlf_k4n8/vpr_arch/UMC22nm_vpr.xml
+++ b/qlf_k4n8/vpr_arch/UMC22nm_vpr.xml
@@ -1,50 +1,5 @@
-<!--
-Low-cost homogeneous FPGA Architecture.
-
-- UMC22nm technology
-- General purpose logic block: 
-K = 4, N = 8, fracturable 4 LUTs (can operate as one 4-LUT or two 3-LUTs with all 3 inputs shared) 
-with optionally registered outputs
-- Routing architecture:
-- 10% L = 1, fc_in = 0.15, Fc_out = 0.10
-- 10% L = 2, fc_in = 0.15, Fc_out = 0.10
-- 80% L = 4, fc_in = 0.15, Fc_out = 0.10
-- 100 routing tracks per channel
-
-Authors: Xifan Tang
--->
 <architecture>
-  <!-- 
-    ODIN II specific config begins 
-    Describes the types of user-specified netlist blocks (in blif, this corresponds to 
-    ".model [type_of_block]") that this architecture supports.
-
-    Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
-    already special structures in blif (.names, .input, .output, and .latch) 
-    that describe them.
-  -->
   <models>
-    <!-- A virtual model for I/O to be used in the physical mode of io block -->
-    <!--model name="frac_lut4">
-      <input_ports>
-      <port name="in" combinational_sink_ports="lut2_out lut4_out"/>
-      </input_ports>
-      <output_ports>
-      <port name="lut2_out"/>
-      <port name="lut4_out"/>
-      </output_ports>
-    </model-->
-    <!--model name="carry_follower">
-      <input_ports>
-      <port name="a" combinational_sink_ports="cout"/>
-      <port name="b" combinational_sink_ports="cout"/>
-      <port name="cin" combinational_sink_ports="cout"/>
-      </input_ports>
-      <output_ports>
-      <port name="cout"/>
-      </output_ports>
-    </model-->
-    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
     <model name="io" never_prune="true">
       <input_ports>
         <port name="outpad"/>
@@ -165,15 +120,6 @@ Authors: Xifan Tang
     </model>
   </models>
   <tiles>
-    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
-      If you need to register the I/O, define clocks in the circuit models
-      These clocks can be handled in back-end
-    -->
-    <!-- Top-side has 1 I/O per tile -->
-    <!-- Right-side has 1 I/O per tile -->
-    <!-- Bottom-side has 9 I/O per tile -->
-    <!-- Left-side has 1 I/O per tile -->
-    <!-- CLB has most pins on the top and right sides -->
     <tile area="0" name="io_top">
       <sub_tile capacity="16" name="io_top">
         <equivalent_sites>
@@ -185,16 +131,14 @@ Authors: Xifan Tang
         <input name="sc_in" num_pins="1"/>
         <output name="sc_out" num_pins="1"/>
         <input name="reset" num_pins="1" is_non_clock_global="true"/>
-        <input name="scan_mode" num_pins="1" is_non_clock_global="true"/>
         <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
           <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
           <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
           <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
           <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
-          <fc_override port_name="scan_mode" fc_type="frac" fc_val="0"/>
         </fc>
         <pinlocations pattern="custom">
-          <loc side="bottom">io_top.a2f_o io_top.f2a_i io_top.clk io_top.sc_in io_top.sc_out io_top.reset io_top.scan_mode</loc>
+          <loc side="bottom">io_top.a2f_o io_top.f2a_i io_top.clk io_top.sc_in io_top.sc_out io_top.reset</loc>
         </pinlocations>
       </sub_tile>
     </tile>
@@ -209,16 +153,14 @@ Authors: Xifan Tang
         <input name="sc_in" num_pins="1"/>
         <output name="sc_out" num_pins="1"/>
         <input name="reset" num_pins="1" is_non_clock_global="true"/>
-        <input name="scan_mode" num_pins="1" is_non_clock_global="true"/>
         <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
           <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
           <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
           <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
           <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
-          <fc_override port_name="scan_mode" fc_type="frac" fc_val="0"/>
         </fc>
         <pinlocations pattern="custom">
-          <loc side="left">io_right.a2f_o io_right.f2a_i io_right.clk io_right.sc_in io_right.sc_out io_right.reset io_right.scan_mode</loc>
+          <loc side="left">io_right.a2f_o io_right.f2a_i io_right.clk io_right.sc_in io_right.sc_out io_right.reset</loc>
         </pinlocations>
       </sub_tile>
     </tile>
@@ -233,16 +175,14 @@ Authors: Xifan Tang
         <input name="sc_in" num_pins="1"/>
         <output name="sc_out" num_pins="1"/>
         <input name="reset" num_pins="1" is_non_clock_global="true"/>
-        <input name="scan_mode" num_pins="1" is_non_clock_global="true"/>
         <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
           <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
           <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
           <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
           <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
-          <fc_override port_name="scan_mode" fc_type="frac" fc_val="0"/>
         </fc>
         <pinlocations pattern="custom">
-          <loc side="top">io_bottom.a2f_o io_bottom.f2a_i io_bottom.clk io_bottom.sc_in io_bottom.sc_out io_bottom.reset io_bottom.scan_mode</loc>
+          <loc side="top">io_bottom.a2f_o io_bottom.f2a_i io_bottom.clk io_bottom.sc_in io_bottom.sc_out io_bottom.reset</loc>
         </pinlocations>
       </sub_tile>
     </tile>
@@ -257,16 +197,14 @@ Authors: Xifan Tang
         <input name="sc_in" num_pins="1"/>
         <output name="sc_out" num_pins="1"/>
         <input name="reset" num_pins="1" is_non_clock_global="true"/>
-        <input name="scan_mode" num_pins="1" is_non_clock_global="true"/>
         <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
           <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
           <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
           <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
           <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
-          <fc_override port_name="scan_mode" fc_type="frac" fc_val="0"/>
         </fc>
         <pinlocations pattern="custom">
-          <loc side="right">io_left.a2f_o io_left.f2a_i io_left.clk io_left.sc_in io_left.sc_out io_left.reset io_left.scan_mode</loc>
+          <loc side="right">io_left.a2f_o io_left.f2a_i io_left.clk io_left.sc_in io_left.sc_out io_left.reset</loc>
         </pinlocations>
       </sub_tile>
     </tile>
@@ -282,7 +220,6 @@ Authors: Xifan Tang
         <input name="lreset" num_pins="1"/>
         <input name="reset" num_pins="1" is_non_clock_global="true"/>
         <input name="preset" num_pins="1"/>
-        <input name="scan_mode" num_pins="1" is_non_clock_global="true"/>
         <output name="O" num_pins="8" equivalent="none"/>
         <output name="reg_out" num_pins="1"/>
         <output name="sc_out" num_pins="1"/>
@@ -295,11 +232,9 @@ Authors: Xifan Tang
           <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
           <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
           <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
-          <fc_override port_name="scan_mode" fc_type="frac" fc_val="0"/>
         </fc>
-        <!--pinlocations pattern="spread"/-->
         <pinlocations pattern="custom">
-          <loc side="left">clb.clk clb.reset clb.lreset clb.preset clb.scan_mode</loc>
+          <loc side="left">clb.clk clb.reset clb.lreset clb.preset</loc>
           <loc side="top">clb.reg_in clb.sc_in clb.cin clb.O[7:0] clb.I[11:0]</loc>
           <loc side="right">clb.I[23:12]</loc>
           <loc side="bottom">clb.reg_out clb.sc_out clb.cout</loc>
@@ -307,28 +242,8 @@ Authors: Xifan Tang
       </sub_tile>
     </tile>
   </tiles>
-  <!-- ODIN II specific config ends -->
-  <!-- Physical descriptions begin -->
   <device>
-    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
-      models. We are modifying the delay values however, to include metal C and R, which allows more architecture
-      experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
-      (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
-      45 nm in general). I'm upping the Rmin_nmos from Ian's just over 6k to nearly 9k, and dropping 
-      RminW_pmos from 18k to 16k to hit this 1.8x ratio, while keeping the delays of buffers approximately
-      lined up with Stratix IV. 
-      We are using Jeff G.'s capacitance data for 45 nm (in tech/ptm_45nm).
-      Jeff's tables list C in for transistors with widths in multiples of the minimum feature size (45 nm).
-      The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply drive strength sizes in this file
-      by 2.5x when looking up in Jeff's tables.
-      The delay values are lined up with Stratix IV, which has an architecture similar to this
-      proposed FPGA, and which is also 40 nm 
-      C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-    4x minimum drive strength buffer. -->
     <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
-    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
-        area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-      -->
     <area grid_logic_tile_area="0"/>
     <chan_width_distr>
       <x distr="uniform" peak="1.000000"/>
@@ -338,30 +253,12 @@ Authors: Xifan Tang
     <switch_block fs="3" type="wilton"/>
   </device>
   <switchlist>
-    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
-      book area formula. This means the mux transistors are about 5x minimum drive strength.
-      We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
-      mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
-      the n and p transistors in the first stage are equal-sized to lower the buffer trip point, since it's fed
-      by a pass transistor mux. We can then reverse engineer the buffer second stage to hit the specified 
-      buf_size (really buffer area) - 16.2x minimum drive nmos and 1.8*16.2 = 29.2x minimum drive.
-      I then took the data from Jeff G.'s PTM modeling of 45 nm to get the Cin (gate of first stage) and Cout 
-      (diff of second stage) listed below.  Jeff's models are in tech/ptm_45nm, and are in min feature multiples.
-      The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
-      2.5x when looking up in Jeff's tables.
-      Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-    This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
     <switch type="mux" name="L1_mux" R="0." Cin=".77e-15" Cout="0." Tdel="120e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
     <switch type="mux" name="L2_mux" R="0." Cin=".77e-15" Cout="0." Tdel="250e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
     <switch type="mux" name="L4_mux" R="0." Cin=".77e-15" Cout="0." Tdel="480e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
-    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
     <switch type="mux" name="ipin_cblock" R="0." Cout="0." Cin="1.47e-15" Tdel="135e-12" mux_trans_size="1.222260" buf_size="auto"/>
   </switchlist>
   <segmentlist>
-    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
-      With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-    reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
-    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
     <segment name="L1" freq="0.20" length="1" type="unidir" Rmetal="0" Cmetal="22.5e-15">
       <mux name="L1_mux"/>
       <sb type="pattern">1 1</sb>
@@ -380,11 +277,9 @@ Authors: Xifan Tang
   </segmentlist>
   <directlist>
     <direct name="carry_chain" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
-    <!--direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/-->
     <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>
   </directlist>
   <complexblocklist>
-    <!-- Define input pads begin -->
     <pb_type name="io">
       <clock name="clk" num_pins="4"/>
       <input name="f2a_i" num_pins="1"/>
@@ -392,9 +287,6 @@ Authors: Xifan Tang
       <input name="sc_in" num_pins="1"/>
       <output name="sc_out" num_pins="1"/>
       <input name="reset" num_pins="1" is_non_clock_global="true"/>
-      <input name="scan_mode" num_pins="1" is_non_clock_global="true"/>
-      <!-- Physical mode definition begin (physical implementation of the io) -->
-      <!-- Physical mode definition end (physical implementation of the io) -->
       <mode name="io_output">
         <pb_type name="io_output" num_pb="1">
           <clock name="clk" num_pins="1"/>
@@ -415,7 +307,6 @@ Authors: Xifan Tang
               </pb_type>
               <interconnect>
                 <direct input="LATCH.Q" name="LATCH-Q" output="ff.Q">
-                  <!--pack_pattern name="pack-OREG" in_port="LATCH.Q" out_port="ff.Q"/-->
                 </direct>
                 <direct input="ff.D" name="LATCH-D" output="LATCH.D">
                 </direct>
@@ -503,7 +394,6 @@ Authors: Xifan Tang
               <interconnect>
                 <direct input="LATCH.Q" name="LATCH-Q" output="ff.Q"/>
                 <direct input="ff.D" name="LATCH-D" output="LATCH.D">
-                  <!--pack_pattern name="pack-IREG" in_port="ff.D" out_port="LATCH.D"/-->
                 </direct>
                 <direct input="ff.clk" name="LATCH-clk" output="LATCH.clk"/>
               </interconnect>
@@ -519,7 +409,6 @@ Authors: Xifan Tang
               <interconnect>
                 <direct input="DFF.Q" name="FF-Q" output="ff.Q"/>
                 <direct input="ff.D" name="DFF-D" output="DFF.D">
-                  <!--pack_pattern name="pack-IREG" in_port="ff.D" out_port="DFF.D"/-->
                 </direct>
                 <direct input="ff.clk" name="DFF-clk" output="DFF.C"/>
               </interconnect>
@@ -535,7 +424,6 @@ Authors: Xifan Tang
               <interconnect>
                 <direct input="DFFN.Q" name="FF-Q" output="ff.Q"/>
                 <direct input="ff.D" name="DFFN-D" output="DFFN.D">
-                  <!--pack_pattern name="pack-IREG" in_port="ff.D" out_port="DFF.D"/-->
                 </direct>
                 <direct input="ff.clk" name="DFFN-clk" output="DFFN.C"/>
               </interconnect>
@@ -582,6 +470,7 @@ Authors: Xifan Tang
             <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
             <metadata>
               <meta name="fasm_prefix">logical_tile_io_mode_physical__iopad_mode_default__ff_0 logical_tile_io_mode_physical__iopad_mode_default__ff_1</meta>
+              <meta name="fasm_params">QL_IOFF_QL_CCFF_mem.mem_out = MODE</meta>
             </metadata>
           </pb_type>
           <pb_type name="pad" blif_model=".subckt io" num_pb="1">
@@ -635,13 +524,6 @@ ff[1].Q : mem_iopad_a2f_o_0.mem_out[0]</meta>
         </interconnect>
       </mode>
     </pb_type>
-    <!-- Define I/O pads ends -->
-    <!-- Define general purpose logic block (CLB) begin -->
-    <!-- -Due to the absence of local routing, 
-      the 4 inputs of fracturable LUT4 are no longer equivalent, 
-      because the 4th input can not be switched when the dual-LUT3 modes are used.
-      So pin equivalence should be applied to the first 3 inputs only
-    -->
     <pb_type name="clb">
       <input name="I" num_pins="24" equivalent="full"/>
       <input name="reg_in" num_pins="1"/>
@@ -650,16 +532,11 @@ ff[1].Q : mem_iopad_a2f_o_0.mem_out[0]</meta>
       <input name="lreset" num_pins="1"/>
       <input name="reset" num_pins="1" is_non_clock_global="true"/>
       <input name="preset" num_pins="1"/>
-      <input name="scan_mode" num_pins="1" is_non_clock_global="true"/>
       <output name="O" num_pins="8" equivalent="none"/>
       <output name="reg_out" num_pins="1"/>
       <output name="sc_out" num_pins="1"/>
       <output name="cout" num_pins="1"/>
       <clock name="clk" num_pins="4"/>
-      <!-- Describe fracturable logic element.  
-          Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
-          The outputs of the fracturable logic element can be optionally registered
-        -->
       <pb_type name="fle" num_pb="8">
         <input name="in" num_pins="4"/>
         <input name="reg_in" num_pins="1"/>
@@ -667,36 +544,21 @@ ff[1].Q : mem_iopad_a2f_o_0.mem_out[0]</meta>
         <input name="cin" num_pins="1"/>
         <input name="reset" num_pins="1"/>
         <input name="preset" num_pins="1"/>
-        <input name="scan_mode" num_pins="1"/>
         <output name="out" num_pins="1"/>
         <output name="reg_out" num_pins="1"/>
         <output name="sc_out" num_pins="1"/>
         <output name="cout" num_pins="1"/>
         <clock name="clk" num_pins="1"/>
-        <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <!-- Physical mode definition end (physical implementation of the fle) -->
         <mode name="n1_lut4">
-          <!-- Define 4-LUT mode -->
           <pb_type name="ble4" num_pb="1">
             <input name="in" num_pins="4"/>
             <input name="reset" num_pins="1"/>
             <input name="preset" num_pins="1"/>
             <output name="out" num_pins="1"/>
             <clock name="clk" num_pins="1"/>
-            <!-- Define LUT -->
             <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
               <input name="in" num_pins="4" port_class="lut_in"/>
               <output name="out" num_pins="1" port_class="lut_out"/>
-              <!-- LUT timing using delay matrix -->
-              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
-                  we instead take the average of these numbers to get more stable results
-                  82e-12
-                  173e-12
-                  261e-12
-                  263e-12
-                  398e-12
-                  397e-12
-                -->
               <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                 170e-12
                 170e-12
@@ -710,7 +572,6 @@ ff[1].Q : mem_iopad_a2f_o_0.mem_out[0]</meta>
                 30e-12
               </delay_matrix>
             </pb_type>
-            <!-- Define flip-flop -->
             <pb_type name="ff" num_pb="1">
               <input name="D" num_pins="1"/>
               <input name="R" num_pins="1"/>
@@ -838,14 +699,12 @@ ff[1].Q : mem_iopad_a2f_o_0.mem_out[0]</meta>
             <interconnect>
               <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
               <direct name="direct2" input="lut4.out" output="ff.D">
-                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
                 <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
               </direct>
               <direct name="direct3" input="ble4.clk" output="ff.clk"/>
               <direct name="direct4" input="ble4.reset" output="ff.R"/>
               <direct name="direct5" input="ble4.preset" output="ff.S"/>
               <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
-                <!-- LUT to output is faster than FF to output on a Stratix IV -->
                 <delay_constant max="90e-12" min="50e-12" in_port="lut4.out" out_port="ble4.out"/>
                 <delay_constant max="100e-12" min="50e-12" in_port="ff.Q" out_port="ble4.out"/>
               </mux>
@@ -859,8 +718,6 @@ ff[1].Q : mem_iopad_a2f_o_0.mem_out[0]</meta>
             <direct name="direct5" input="fle.preset" output="ble4.preset"/>
           </interconnect>
         </mode>
-        <!-- 4-LUT mode definition end -->
-        <!-- Define shift register begin -->
         <mode name="shift_register">
           <pb_type name="shift_reg" num_pb="1">
             <input name="reg_in" num_pins="1"/>
@@ -910,15 +767,12 @@ ff[1].Q : mem_iopad_a2f_o_0.mem_out[0]</meta>
             </direct>
           </interconnect>
         </mode>
-        <!-- Define shift register end -->
-        <!-- 1-bit soft adder definition begin-->
         <mode name="arithmetic">
           <pb_type name="soft_adder" num_pb="1">
             <input name="in" num_pins="4"/>
             <input name="cin" num_pins="1"/>
             <output name="sumout" num_pins="1"/>
             <output name="cout" num_pins="1"/>
-            <!-- Define special LUT marco to be used as adder -->
             <pb_type name="adder_lut4" blif_model=".subckt adder_lut4" num_pb="1">
               <input name="cin" num_pins="1"/>
               <input name="in" num_pins="4"/>
@@ -932,11 +786,9 @@ ff[1].Q : mem_iopad_a2f_o_0.mem_out[0]</meta>
             <interconnect>
               <direct name="direct1" input="soft_adder.in" output="adder_lut4.in"/>
               <direct name="direct3" input="soft_adder.cin" output="adder_lut4.cin">
-                <!-- Pack pattern to build an adder chain connection considered by packer -->
                 <pack_pattern name="chain" in_port="soft_adder.cin" out_port="adder_lut4.cin"/>
               </direct>
               <direct name="direct4" input="adder_lut4.cout" output="soft_adder.cout">
-                <!-- Pack pattern to build an adder chain connection considered by packer -->
                 <pack_pattern name="chain" in_port="adder_lut4.cout" out_port="soft_adder.cout"/>
               </direct>
               <direct name="direct5" input="adder_lut4.lut4_out" output="soft_adder.sumout[0:0]">
@@ -946,17 +798,14 @@ ff[1].Q : mem_iopad_a2f_o_0.mem_out[0]</meta>
           <interconnect>
             <direct name="direct1" input="fle.in" output="soft_adder.in"/>
             <direct name="direct2" input="fle.cin" output="soft_adder.cin">
-              <!-- Pack pattern to build an adder chain connection considered by packer -->
               <pack_pattern name="chain" in_port="fle.cin" out_port="soft_adder.cin"/>
             </direct>
             <direct name="direct3" input="soft_adder.sumout" output="fle.out[0:0]"/>
             <direct name="direct4" input="soft_adder.cout" output="fle.cout">
-              <!-- Pack pattern to build an adder chain connection considered by packer -->
               <pack_pattern name="chain" in_port="soft_adder.cout" out_port="fle.cout"/>
             </direct>
           </interconnect>
         </mode>
-        <!-- 1-bit soft adder definition end-->
         <mode name="physical">
           <pb_type name="fabric" num_pb="1">
             <input name="in" num_pins="4"/>
@@ -975,7 +824,6 @@ ff[1].Q : mem_iopad_a2f_o_0.mem_out[0]</meta>
               <input name="cin" num_pins="1"/>
               <output name="out" num_pins="1"/>
               <output name="cout" num_pins="1"/>
-              <!-- Define LUT -->
               <pb_type name="frac_lut4_arith" blif_model=".subckt frac_lut4_arith" num_pb="1">
                 <input name="in" num_pins="4"/>
                 <input name="cin" num_pins="1"/>
@@ -1001,7 +849,6 @@ frac_lut4_arith_QL_CCFF_mem.mem_out = MODE</meta>
                 <meta name="fasm_prefix">logical_tile_clb_mode_default__fle_mode_physical__fabric_mode_default__frac_logic_0</meta>
               </metadata>
             </pb_type>
-            <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->
             <pb_type name="ff" blif_model=".subckt scff_1" num_pb="1">
               <input name="D" num_pins="1"/>
               <input name="DI" num_pins="1"/>
@@ -1016,6 +863,7 @@ frac_lut4_arith_QL_CCFF_mem.mem_out = MODE</meta>
               <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
               <metadata>
                 <meta name="fasm_prefix">logical_tile_clb_mode_default__fle_mode_physical__fabric_mode_default__ff_0</meta>
+                <meta name="fasm_params">QL_FF_QL_CCFF_mem.mem_out = MODE</meta>
               </metadata>
             </pb_type>
             <interconnect>
@@ -1035,7 +883,6 @@ fabric.reg_in : mem_ff_0_D_0.mem_out[0]</meta>
                 </metadata>
               </mux>
               <mux name="mux2" input="ff.Q frac_logic.out" output="fabric.out">
-                <!-- LUT to output is faster than FF to output on a Stratix IV -->
                 <delay_constant max="25e-12" in_port="frac_logic.out" out_port="fabric.out"/>
                 <delay_constant max="45e-12" in_port="ff.Q" out_port="fabric.out"/>
                 <metadata>
@@ -1071,24 +918,10 @@ frac_logic.out : mem_fabric_out_0.mem_out[0]</meta>
         </metadata>
       </pb_type>
       <interconnect>
-        <!-- We use direct connections to reduce the area to the most
-          The global local routing is going to compensate the loss in routability
-        -->
-        <!-- FIXME: The implicit port definition results in I0[0] connected to
-          in[2]. Such twisted connection is not expected.
-          I[0] should be connected to in[0]
-        -->
-        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
-          By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
-          then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
-          naive specification).
-        -->
         <direct name="clbouts1" input="fle[3:0].out" output="clb.O[3:0]"/>
         <direct name="clbouts2" input="fle[7:4].out" output="clb.O[7:4]"/>
-        <!-- Shift register chain links -->
         <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">
           <pack_pattern name="shiftchain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>
-          <!-- Put all inter-block carry chain delay on this one edge -->
           <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>
         </direct>
         <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">
@@ -1097,18 +930,14 @@ frac_logic.out : mem_fabric_out_0.mem_out[0]</meta>
         <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">
           <pack_pattern name="shiftchain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/>
         </direct>
-        <!-- Scan chain links -->
         <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">
-          <!-- Put all inter-block carry chain delay on this one edge -->
           <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>
         </direct>
         <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
         </direct>
         <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
         </direct>
-        <!-- Carry chain links -->
         <direct name="carry_chain_in" input="clb.cin" output="fle[0:0].cin">
-          <!-- Put all inter-block carry chain delay on this one edge -->
           <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
           <delay_constant max="0.07e-9" min="0.03e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
         </direct>
@@ -2390,22 +2219,11 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
         <direct input="clb.preset" name="presets_clb.preset_to_fle[5].preset" output="fle[5].preset"/>
         <direct input="clb.preset" name="presets_clb.preset_to_fle[6].preset" output="fle[6].preset"/>
         <direct input="clb.preset" name="presets_clb.preset_to_fle[7].preset" output="fle[7].preset"/>
-        <direct input="clb.scan_mode" name="scan_modes_clb.scan_mode_to_fle[0].scan_mode" output="fle[0].scan_mode"/>
-        <direct input="clb.scan_mode" name="scan_modes_clb.scan_mode_to_fle[1].scan_mode" output="fle[1].scan_mode"/>
-        <direct input="clb.scan_mode" name="scan_modes_clb.scan_mode_to_fle[2].scan_mode" output="fle[2].scan_mode"/>
-        <direct input="clb.scan_mode" name="scan_modes_clb.scan_mode_to_fle[3].scan_mode" output="fle[3].scan_mode"/>
-        <direct input="clb.scan_mode" name="scan_modes_clb.scan_mode_to_fle[4].scan_mode" output="fle[4].scan_mode"/>
-        <direct input="clb.scan_mode" name="scan_modes_clb.scan_mode_to_fle[5].scan_mode" output="fle[5].scan_mode"/>
-        <direct input="clb.scan_mode" name="scan_modes_clb.scan_mode_to_fle[6].scan_mode" output="fle[6].scan_mode"/>
-        <direct input="clb.scan_mode" name="scan_modes_clb.scan_mode_to_fle[7].scan_mode" output="fle[7].scan_mode"/>
       </interconnect>
-      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
-      <!-- Place this general purpose logic block in any unspecified column -->
     </pb_type>
-    <!-- Define general purpose logic block (CLB) ends -->
   </complexblocklist>
   <layout>
-    <fixed_layout height="34" name="qlf_k4n8-qlf_k4n8_umc22" width="34">
+    <fixed_layout height="26" name="qlf_k4n8-qlf_k4n8_umc22" width="26">
       <single priority="10" type="io_left" x="0" y="1">
         <metadata>
           <meta name="fasm_prefix">fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__0 fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__1 fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__2 fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__3 fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__4 fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__5 fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__6 fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__7 fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__8 fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__9 fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__10 fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__11 fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__12 fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__13 fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__14 fpga_top.grid_io_left_left_0__1_.logical_tile_io_mode_io__15</meta>
@@ -2524,46 +2342,6 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
       <single priority="10" type="io_left" x="0" y="24">
         <metadata>
           <meta name="fasm_prefix">fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__0 fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__1 fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__2 fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__3 fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__4 fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__5 fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__6 fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__7 fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__8 fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__9 fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__10 fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__11 fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__12 fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__13 fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__14 fpga_top.grid_io_left_left_0__24_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_left" x="0" y="25">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_left_left_0__25_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_left" x="0" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__0 fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__1 fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__2 fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__3 fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__4 fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__5 fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__6 fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__7 fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__8 fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__9 fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__10 fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__11 fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__12 fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__13 fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__14 fpga_top.grid_io_left_left_0__26_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_left" x="0" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__0 fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__1 fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__2 fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__3 fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__4 fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__5 fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__6 fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__7 fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__8 fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__9 fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__10 fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__11 fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__12 fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__13 fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__14 fpga_top.grid_io_left_left_0__27_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_left" x="0" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__0 fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__1 fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__2 fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__3 fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__4 fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__5 fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__6 fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__7 fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__8 fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__9 fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__10 fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__11 fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__12 fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__13 fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__14 fpga_top.grid_io_left_left_0__28_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_left" x="0" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__0 fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__1 fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__2 fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__3 fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__4 fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__5 fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__6 fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__7 fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__8 fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__9 fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__10 fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__11 fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__12 fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__13 fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__14 fpga_top.grid_io_left_left_0__29_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_left" x="0" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__0 fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__1 fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__2 fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__3 fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__4 fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__5 fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__6 fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__7 fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__8 fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__9 fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__10 fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__11 fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__12 fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__13 fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__14 fpga_top.grid_io_left_left_0__30_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_left" x="0" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__0 fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__1 fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__2 fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__3 fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__4 fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__5 fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__6 fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__7 fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__8 fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__9 fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__10 fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__11 fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__12 fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__13 fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__14 fpga_top.grid_io_left_left_0__31_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_left" x="0" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__0 fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__1 fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__2 fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__3 fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__4 fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__5 fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__6 fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__7 fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__8 fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__9 fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__10 fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__11 fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__12 fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__13 fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__14 fpga_top.grid_io_left_left_0__32_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="1" y="0">
@@ -2691,49 +2469,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_1__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="1" y="25">
+      <single priority="10" type="io_top" x="1" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_1__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="1" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_1__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="1" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_1__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="1" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_1__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="1" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_1__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="1" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_1__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="1" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_1__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="1" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_1__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="1" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_1__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_1__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="2" y="0">
@@ -2861,49 +2599,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_2__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="2" y="25">
+      <single priority="10" type="io_top" x="2" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_2__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="2" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_2__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="2" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_2__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="2" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_2__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="2" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_2__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="2" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_2__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="2" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_2__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="2" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_2__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="2" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_2__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_2__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="3" y="0">
@@ -3031,49 +2729,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_3__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="3" y="25">
+      <single priority="10" type="io_top" x="3" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_3__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="3" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_3__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="3" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_3__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="3" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_3__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="3" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_3__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="3" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_3__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="3" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_3__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="3" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_3__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="3" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_3__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_3__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="4" y="0">
@@ -3201,49 +2859,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_4__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="4" y="25">
+      <single priority="10" type="io_top" x="4" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_4__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="4" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_4__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="4" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_4__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="4" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_4__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="4" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_4__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="4" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_4__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="4" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_4__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="4" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_4__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="4" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_4__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_4__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="5" y="0">
@@ -3371,49 +2989,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_5__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="5" y="25">
+      <single priority="10" type="io_top" x="5" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_5__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="5" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_5__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="5" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_5__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="5" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_5__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="5" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_5__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="5" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_5__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="5" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_5__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="5" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_5__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="5" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_5__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_5__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="6" y="0">
@@ -3541,49 +3119,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_6__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="6" y="25">
+      <single priority="10" type="io_top" x="6" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_6__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="6" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_6__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="6" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_6__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="6" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_6__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="6" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_6__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="6" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_6__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="6" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_6__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="6" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_6__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="6" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_6__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_6__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="7" y="0">
@@ -3711,49 +3249,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_7__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="7" y="25">
+      <single priority="10" type="io_top" x="7" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_7__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="7" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_7__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="7" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_7__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="7" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_7__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="7" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_7__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="7" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_7__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="7" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_7__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="7" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_7__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="7" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_7__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_7__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="8" y="0">
@@ -3881,49 +3379,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_8__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="8" y="25">
+      <single priority="10" type="io_top" x="8" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_8__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="8" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_8__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="8" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_8__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="8" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_8__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="8" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_8__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="8" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_8__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="8" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_8__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="8" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_8__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="8" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_8__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_8__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="9" y="0">
@@ -4051,49 +3509,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_9__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="9" y="25">
+      <single priority="10" type="io_top" x="9" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_9__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="9" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_9__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="9" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_9__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="9" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_9__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="9" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_9__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="9" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_9__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="9" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_9__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="9" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_9__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="9" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_9__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_9__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="10" y="0">
@@ -4221,49 +3639,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_10__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="10" y="25">
+      <single priority="10" type="io_top" x="10" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_10__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="10" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_10__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="10" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_10__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="10" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_10__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="10" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_10__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="10" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_10__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="10" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_10__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="10" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_10__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="10" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_10__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_10__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="11" y="0">
@@ -4391,49 +3769,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_11__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="11" y="25">
+      <single priority="10" type="io_top" x="11" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_11__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="11" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_11__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="11" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_11__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="11" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_11__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="11" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_11__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="11" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_11__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="11" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_11__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="11" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_11__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="11" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_11__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_11__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="12" y="0">
@@ -4561,49 +3899,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_12__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="12" y="25">
+      <single priority="10" type="io_top" x="12" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_12__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="12" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_12__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="12" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_12__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="12" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_12__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="12" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_12__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="12" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_12__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="12" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_12__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="12" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_12__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="12" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_12__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_12__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="13" y="0">
@@ -4731,49 +4029,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_13__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="13" y="25">
+      <single priority="10" type="io_top" x="13" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_13__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="13" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_13__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="13" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_13__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="13" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_13__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="13" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_13__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="13" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_13__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="13" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_13__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="13" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_13__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="13" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_13__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_13__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="14" y="0">
@@ -4901,49 +4159,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_14__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="14" y="25">
+      <single priority="10" type="io_top" x="14" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_14__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="14" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_14__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="14" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_14__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="14" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_14__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="14" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_14__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="14" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_14__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="14" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_14__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="14" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_14__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="14" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_14__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_14__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="15" y="0">
@@ -5071,49 +4289,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_15__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="15" y="25">
+      <single priority="10" type="io_top" x="15" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_15__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="15" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_15__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="15" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_15__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="15" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_15__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="15" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_15__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="15" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_15__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="15" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_15__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="15" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_15__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="15" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_15__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_15__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="16" y="0">
@@ -5241,49 +4419,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_16__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="16" y="25">
+      <single priority="10" type="io_top" x="16" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_16__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="16" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_16__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="16" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_16__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="16" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_16__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="16" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_16__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="16" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_16__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="16" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_16__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="16" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_16__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="16" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_16__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_16__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="17" y="0">
@@ -5411,49 +4549,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_17__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="17" y="25">
+      <single priority="10" type="io_top" x="17" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_17__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="17" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_17__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="17" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_17__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="17" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_17__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="17" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_17__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="17" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_17__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="17" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_17__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="17" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_17__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="17" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_17__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_17__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="18" y="0">
@@ -5581,49 +4679,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_18__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="18" y="25">
+      <single priority="10" type="io_top" x="18" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_18__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="18" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_18__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="18" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_18__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="18" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_18__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="18" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_18__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="18" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_18__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="18" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_18__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="18" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_18__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="18" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_18__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_18__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="19" y="0">
@@ -5751,49 +4809,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_19__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="19" y="25">
+      <single priority="10" type="io_top" x="19" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_19__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="19" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_19__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="19" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_19__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="19" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_19__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="19" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_19__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="19" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_19__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="19" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_19__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="19" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_19__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="19" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_19__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_19__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="20" y="0">
@@ -5921,49 +4939,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_20__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="20" y="25">
+      <single priority="10" type="io_top" x="20" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_20__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="20" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_20__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="20" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_20__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="20" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_20__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="20" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_20__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="20" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_20__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="20" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_20__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="20" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_20__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="20" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_20__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_20__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="21" y="0">
@@ -6091,49 +5069,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_21__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="21" y="25">
+      <single priority="10" type="io_top" x="21" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_21__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="21" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_21__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="21" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_21__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="21" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_21__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="21" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_21__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="21" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_21__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="21" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_21__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="21" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_21__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="21" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_21__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_21__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="22" y="0">
@@ -6261,49 +5199,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_22__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="22" y="25">
+      <single priority="10" type="io_top" x="22" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_22__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="22" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_22__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="22" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_22__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="22" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_22__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="22" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_22__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="22" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_22__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="22" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_22__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="22" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_22__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="22" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_22__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_22__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="23" y="0">
@@ -6431,49 +5329,9 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_23__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="23" y="25">
+      <single priority="10" type="io_top" x="23" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_23__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="23" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_23__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="23" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_23__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="23" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_23__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="23" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_23__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="23" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_23__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="23" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_23__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="23" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_23__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="23" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_23__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_23__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
       <single priority="10" type="io_bottom" x="24" y="0">
@@ -6601,1569 +5459,129 @@ clb.clk[3] : mem_fle_7_clk_0.mem_out[0],mem_fle_7_clk_0.mem_out[1]</meta>
           <meta name="fasm_prefix">fpga_top.grid_clb_24__24_.logical_tile_clb_mode_clb__0</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="24" y="25">
+      <single priority="10" type="io_top" x="24" y="25">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_24__25_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_24__25_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="24" y="26">
+      <single priority="10" type="io_right" x="25" y="1">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_24__26_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__1_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="24" y="27">
+      <single priority="10" type="io_right" x="25" y="2">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_24__27_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__2_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="24" y="28">
+      <single priority="10" type="io_right" x="25" y="3">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_24__28_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__3_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="24" y="29">
+      <single priority="10" type="io_right" x="25" y="4">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_24__29_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__4_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="24" y="30">
+      <single priority="10" type="io_right" x="25" y="5">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_24__30_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__5_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="24" y="31">
+      <single priority="10" type="io_right" x="25" y="6">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_24__31_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__6_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="24" y="32">
+      <single priority="10" type="io_right" x="25" y="7">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_24__32_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__7_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="io_top" x="24" y="33">
+      <single priority="10" type="io_right" x="25" y="8">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_24__33_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__8_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="io_bottom" x="25" y="0">
+      <single priority="10" type="io_right" x="25" y="9">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__0 fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__1 fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__2 fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__3 fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__4 fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__5 fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__6 fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__7 fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__8 fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__9 fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__10 fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__11 fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__12 fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__13 fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__14 fpga_top.grid_io_bottom_bottom_25__0_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__9_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="25" y="1">
+      <single priority="10" type="io_right" x="25" y="10">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__1_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__10_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="25" y="2">
+      <single priority="10" type="io_right" x="25" y="11">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__2_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__11_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="25" y="3">
+      <single priority="10" type="io_right" x="25" y="12">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__3_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__12_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="25" y="4">
+      <single priority="10" type="io_right" x="25" y="13">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__4_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__13_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="25" y="5">
+      <single priority="10" type="io_right" x="25" y="14">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__5_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__14_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="25" y="6">
+      <single priority="10" type="io_right" x="25" y="15">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__6_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__15_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="25" y="7">
+      <single priority="10" type="io_right" x="25" y="16">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__7_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__16_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="25" y="8">
+      <single priority="10" type="io_right" x="25" y="17">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__8_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__17_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="25" y="9">
+      <single priority="10" type="io_right" x="25" y="18">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__9_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__18_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="25" y="10">
+      <single priority="10" type="io_right" x="25" y="19">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__10_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__19_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="25" y="11">
+      <single priority="10" type="io_right" x="25" y="20">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__11_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__20_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="25" y="12">
+      <single priority="10" type="io_right" x="25" y="21">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__12_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__21_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="25" y="13">
+      <single priority="10" type="io_right" x="25" y="22">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__13_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__22_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="25" y="14">
+      <single priority="10" type="io_right" x="25" y="23">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__14_.logical_tile_clb_mode_clb__0</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__23_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
-      <single priority="10" type="clb" x="25" y="15">
+      <single priority="10" type="io_right" x="25" y="24">
         <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__15_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="16">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__16_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="17">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__17_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="18">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__18_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="19">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__19_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="20">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__20_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="21">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__21_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="22">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__22_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="23">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__23_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="24">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__24_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="25">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="25" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_25__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="25" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_25__33_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_bottom" x="26" y="0">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__0 fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__1 fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__2 fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__3 fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__4 fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__5 fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__6 fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__7 fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__8 fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__9 fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__10 fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__11 fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__12 fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__13 fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__14 fpga_top.grid_io_bottom_bottom_26__0_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="1">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__1_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="2">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__2_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="3">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__3_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="4">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__4_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="5">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__5_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="6">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__6_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="7">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__7_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="8">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__8_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="9">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__9_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="10">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__10_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="11">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__11_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="12">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__12_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="13">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__13_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="14">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__14_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="15">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__15_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="16">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__16_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="17">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__17_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="18">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__18_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="19">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__19_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="20">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__20_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="21">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__21_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="22">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__22_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="23">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__23_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="24">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__24_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="25">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="26" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_26__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="26" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_26__33_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_bottom" x="27" y="0">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__0 fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__1 fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__2 fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__3 fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__4 fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__5 fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__6 fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__7 fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__8 fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__9 fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__10 fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__11 fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__12 fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__13 fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__14 fpga_top.grid_io_bottom_bottom_27__0_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="1">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__1_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="2">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__2_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="3">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__3_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="4">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__4_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="5">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__5_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="6">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__6_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="7">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__7_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="8">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__8_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="9">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__9_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="10">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__10_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="11">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__11_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="12">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__12_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="13">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__13_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="14">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__14_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="15">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__15_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="16">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__16_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="17">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__17_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="18">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__18_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="19">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__19_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="20">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__20_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="21">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__21_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="22">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__22_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="23">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__23_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="24">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__24_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="25">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="27" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_27__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="27" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_27__33_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_bottom" x="28" y="0">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__0 fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__1 fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__2 fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__3 fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__4 fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__5 fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__6 fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__7 fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__8 fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__9 fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__10 fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__11 fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__12 fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__13 fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__14 fpga_top.grid_io_bottom_bottom_28__0_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="1">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__1_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="2">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__2_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="3">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__3_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="4">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__4_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="5">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__5_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="6">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__6_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="7">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__7_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="8">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__8_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="9">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__9_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="10">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__10_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="11">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__11_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="12">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__12_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="13">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__13_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="14">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__14_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="15">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__15_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="16">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__16_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="17">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__17_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="18">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__18_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="19">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__19_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="20">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__20_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="21">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__21_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="22">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__22_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="23">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__23_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="24">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__24_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="25">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="28" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_28__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="28" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_28__33_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_bottom" x="29" y="0">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__0 fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__1 fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__2 fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__3 fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__4 fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__5 fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__6 fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__7 fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__8 fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__9 fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__10 fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__11 fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__12 fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__13 fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__14 fpga_top.grid_io_bottom_bottom_29__0_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="1">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__1_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="2">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__2_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="3">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__3_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="4">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__4_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="5">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__5_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="6">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__6_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="7">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__7_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="8">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__8_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="9">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__9_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="10">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__10_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="11">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__11_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="12">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__12_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="13">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__13_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="14">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__14_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="15">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__15_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="16">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__16_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="17">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__17_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="18">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__18_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="19">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__19_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="20">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__20_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="21">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__21_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="22">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__22_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="23">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__23_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="24">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__24_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="25">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="29" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_29__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="29" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_29__33_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_bottom" x="30" y="0">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__0 fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__1 fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__2 fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__3 fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__4 fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__5 fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__6 fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__7 fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__8 fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__9 fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__10 fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__11 fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__12 fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__13 fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__14 fpga_top.grid_io_bottom_bottom_30__0_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="1">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__1_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="2">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__2_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="3">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__3_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="4">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__4_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="5">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__5_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="6">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__6_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="7">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__7_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="8">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__8_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="9">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__9_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="10">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__10_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="11">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__11_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="12">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__12_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="13">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__13_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="14">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__14_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="15">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__15_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="16">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__16_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="17">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__17_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="18">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__18_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="19">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__19_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="20">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__20_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="21">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__21_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="22">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__22_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="23">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__23_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="24">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__24_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="25">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="30" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_30__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="30" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_30__33_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_bottom" x="31" y="0">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__0 fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__1 fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__2 fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__3 fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__4 fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__5 fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__6 fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__7 fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__8 fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__9 fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__10 fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__11 fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__12 fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__13 fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__14 fpga_top.grid_io_bottom_bottom_31__0_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="1">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__1_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="2">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__2_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="3">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__3_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="4">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__4_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="5">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__5_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="6">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__6_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="7">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__7_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="8">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__8_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="9">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__9_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="10">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__10_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="11">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__11_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="12">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__12_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="13">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__13_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="14">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__14_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="15">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__15_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="16">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__16_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="17">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__17_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="18">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__18_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="19">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__19_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="20">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__20_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="21">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__21_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="22">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__22_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="23">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__23_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="24">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__24_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="25">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="31" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_31__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="31" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_31__33_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_bottom" x="32" y="0">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__0 fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__1 fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__2 fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__3 fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__4 fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__5 fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__6 fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__7 fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__8 fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__9 fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__10 fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__11 fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__12 fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__13 fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__14 fpga_top.grid_io_bottom_bottom_32__0_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="1">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__1_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="2">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__2_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="3">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__3_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="4">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__4_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="5">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__5_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="6">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__6_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="7">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__7_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="8">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__8_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="9">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__9_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="10">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__10_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="11">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__11_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="12">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__12_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="13">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__13_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="14">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__14_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="15">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__15_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="16">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__16_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="17">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__17_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="18">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__18_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="19">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__19_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="20">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__20_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="21">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__21_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="22">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__22_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="23">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__23_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="24">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__24_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="25">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__25_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__26_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__27_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__28_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__29_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__30_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__31_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="clb" x="32" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_clb_32__32_.logical_tile_clb_mode_clb__0</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_top" x="32" y="33">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__0 fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__1 fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__2 fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__3 fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__4 fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__5 fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__6 fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__7 fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__8 fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__9 fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__10 fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__11 fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__12 fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__13 fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__14 fpga_top.grid_io_top_top_32__33_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="1">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__1_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="2">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__2_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="3">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__3_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="4">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__4_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="5">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__5_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="6">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__6_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="7">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__7_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="8">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__8_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="9">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__9_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="10">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__10_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="11">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__11_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="12">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__12_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="13">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__13_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="14">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__14_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="15">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__15_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="16">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__16_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="17">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__17_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="18">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__18_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="19">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__19_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="20">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__20_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="21">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__21_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="22">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__22_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="23">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__23_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="24">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__24_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="25">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__25_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="26">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__26_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="27">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__27_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="28">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__28_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="29">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__29_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="30">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__30_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="31">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__31_.logical_tile_io_mode_io__15</meta>
-        </metadata>
-      </single>
-      <single priority="10" type="io_right" x="33" y="32">
-        <metadata>
-          <meta name="fasm_prefix">fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_33__32_.logical_tile_io_mode_io__15</meta>
+          <meta name="fasm_prefix">fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__0 fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__1 fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__2 fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__3 fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__4 fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__5 fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__6 fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__7 fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__8 fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__9 fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__10 fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__11 fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__12 fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__13 fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__14 fpga_top.grid_io_right_right_25__24_.logical_tile_io_mode_io__15</meta>
         </metadata>
       </single>
     </fixed_layout>


### PR DESCRIPTION
This is VPR arch and routing graph for 24x24 qlf_k4n8 device. The VPR architecture XML has all the comments removed. It has been tested with SymbiFlow and works correctly. Once merged the subsequent PR to symbiflow-arch-defs wll update the submodule.