### PR TITLE
qlf_k4n8: fix arch to allow physical .input and .output blif 

### DIFF
--- a/qlf_k4n8/vpr_arch/UMC22nm_vpr.xml
+++ b/qlf_k4n8/vpr_arch/UMC22nm_vpr.xml
@@ -1,13 +1,5 @@
 <architecture>
   <models>
-    <model name="io" never_prune="true">
-      <input_ports>
-        <port name="outpad"/>
-      </input_ports>
-      <output_ports>
-        <port name="inpad"/>
-      </output_ports>
-    </model>
     <model name="adder_lut4" never_prune="true">
       <input_ports>
         <port name="in" combinational_sink_ports="lut4_out cout"/>
@@ -487,12 +479,30 @@
               <meta name="fasm_params">QL_IOFF_QL_CCFF_mem.mem_out = MODE</meta>
             </metadata>
           </pb_type>
-          <pb_type name="pad" blif_model=".subckt io" num_pb="1">
+          <pb_type name="pad" num_pb="1">
             <input name="outpad" num_pins="1"/>
             <output name="inpad" num_pins="1"/>
+            <mode name="inpad">
+              <pb_type name="inpad" blif_model=".input" num_pb="1">
+                <output name="inpad" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="inpad_blif_to_inpad_pad" input="inpad.inpad" output="pad.inpad"/>
+              </interconnect>
+              <metadata>
+                <meta name="fasm_features">IO_QL_CCFF_mem.mem_out</meta>
+              </metadata>
+            </mode>
+            <mode name="outpad">
+              <pb_type name="outpad" blif_model=".output" num_pb="1">
+                <input name="outpad" num_pins="1"/>
+              </pb_type>
+              <interconnect>
+                <direct name="outpad_blif_to_outpad_pad" output="outpad.outpad" input="pad.outpad"/>
+              </interconnect>
+            </mode>
             <metadata>
               <meta name="fasm_prefix">logical_tile_io_mode_physical__iopad_mode_default__pad_0</meta>
-              <meta name="fasm_params">IO_QL_CCFF_mem.mem_out = MODE</meta>
             </metadata>
           </pb_type>
           <interconnect>

--- a/qlf_k4n8/vpr_arch/repacking_rules.json
+++ b/qlf_k4n8/vpr_arch/repacking_rules.json
@@ -2,7 +2,7 @@
   "repacking_rules": [
     {
       "src_pbtype": "io[io_input].io_input.inpad",
-      "dst_pbtype": "io[physical].iopad.pad",
+      "dst_pbtype": "io[physical].iopad.pad[inpad].inpad",
       "index_map": [
         1,
         0
@@ -12,7 +12,7 @@
     },
     {
       "src_pbtype": "io[io_output].io_output.outpad",
-      "dst_pbtype": "io[physical].iopad.pad",
+      "dst_pbtype": "io[physical].iopad.pad[outpad].outpad",
       "index_map": [
         1,
         0


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This commit fixes an issue in the physical description of the IO pb_types, for which, if a block that is not a top-level input/output has an output with no inputs, it is considered by VPR as a constant generator.

Given that the IO physical mode has only two possible settings (`0 == output mode`, `1 == input mode`), the FASM feature is written only in case the input mode is selected. This will enable us to leave unaltered the top level IOs during repacking and let VPR correctly detect clock nets.

The repacker needs adjustments, and this commit also enhances the packing rules to deal with the changes in the physical description of the IO pb_type.

Note: This is a short term solution, as it requires to manually change the architecture. A longer-term solution will require to modify the architecture generation scripts, so to automate the update process.