### PR TITLE
Double IO number in the k6n10 architecture

### DIFF
--- a/qlf_k6n10/vpr_arch/GF12nm_vpr.xml
+++ b/qlf_k6n10/vpr_arch/GF12nm_vpr.xml
@@ -172,7 +172,7 @@
          Each output of the tile can drive 10% of routing tracks
       -->
     <tile name="io" area="0">
-      <sub_tile name="io" capacity="1">
+      <sub_tile name="io" capacity="2">
         <equivalent_sites>
           <site pb_type="io"/>
         </equivalent_sites>

--- a/qlf_k6n10/vpr_rr_graph/GF12nm_vpr.bin.gz
+++ b/qlf_k6n10/vpr_rr_graph/GF12nm_vpr.bin.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93802344c0e3671f2bc8fefe941fd6df1874c573237086712df7f3f24cb99ced
-size 191075310
+oid sha256:28503f12f6014a292db7ea966da8e7ff2d56d5b2a4053e8a9e94ad945961cd91
+size 191898721


### PR DESCRIPTION
This PR adds extra IO's to the qlf_k6n10 device.
It also includes the model definition for QL_DSP, which may change later with further testing.

Signed-off-by: samycharas <samy.charas@cpe.fr>